### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sr_cfg.yml
+++ b/.github/workflows/sr_cfg.yml
@@ -13,6 +13,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build_cfg:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/oxfa/hqygdpz/security/code-scanning/1](https://github.com/oxfa/hqygdpz/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job, limiting the GITHUB_TOKEN scopes to the minimum needed. Here, the `build_cfg` job needs to read and write repository contents (checkout the repo and push commits). It does not interact with issues, pull requests, or other resources, so we can set `permissions: contents: write` at the job (or workflow) level.

The minimal, least-disruptive change is to add a `permissions` section just under the `build_cfg:` job header, before `runs-on`. This will scope the token for that job to `contents: write` only, leaving other scopes at their implicit `none`. No other code changes are needed, since `actions/checkout` and `ad-m/github-push-action` both work with `contents: write`. Concretely, in `.github/workflows/sr_cfg.yml`, insert:

```yaml
    permissions:
      contents: write
```

between lines 15 and 16 as shown, maintaining indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
